### PR TITLE
Specify Java version for compiler plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,9 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
+	<prerequisites>
+		<maven>2.0.9</maven>
+	</prerequisites>
 	<build>
 		<plugins>
 			<plugin>
@@ -19,6 +22,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
 				<configuration>
 					<source>1.6</source>
 					<target>1.6</target>


### PR DESCRIPTION
In Maven 3 (other versions not checked), building without specifying the Java version gives errors like: "error: generics are not supported in -source 1.3 (use -source 5 or higher to enable generics)". This change fixes the issue.
