### PR TITLE
immediately return instead of declaring a local variable

### DIFF
--- a/src/main/java/org/nibor/git_merge_repos/MergedRef.java
+++ b/src/main/java/org/nibor/git_merge_repos/MergedRef.java
@@ -45,8 +45,7 @@ public class MergedRef {
 			appendRepositoryNames(messageBuilder, configsWithoutRef);
 		}
 		messageBuilder.append("\n");
-		String message = messageBuilder.toString();
-		return message;
+		return messageBuilder.toString();;
 	}
 
 	private static void appendRepositoryNames(StringBuilder builder,


### PR DESCRIPTION
@robinst hello, I have used your project, and will do some commit to Improve the Code Quality for your project with Sonarqube.
Local Variables should not be declared and then immediately returned or thrown. Declaring a variable only to immediately return or throw it is a bad practice.
[https://rules.sonarsource.com/java/RSPEC-1488](url)