### PR TITLE
Replace `git filter-branch` with `git filter-repo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,7 @@ With the same example as above, do the following for each repository beforehand
 
     cd repo
 
-    git filter-branch --index-filter \
-      'tab=$(printf "\t") && git ls-files -s --error-unmatch . >/dev/null 2>&1; [ $? != 0 ] || (git ls-files -s | sed "s~$tab\"*~&newsubdir/~" | GIT_INDEX_FILE=$GIT_INDEX_FILE.new git update-index --index-info && mv "$GIT_INDEX_FILE.new" "$GIT_INDEX_FILE")' \
-      --tag-name-filter cat \
-      -- --all
+    git filter-repo --to-subdirectory-filter newsubdir
 
 Then, run the program like this:
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Then, run the program like this:
     ./run.sh /absolute/path/to/foo:. /absolute/path/to/bar:.
 
 This time, we don't want the merge commit to change the directory structure, as
-we already did that using `git filter-branch`.
+we already did that using `git filter-repo`.
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ in `bardir`.
 
 ### Preserve History for Paths
 
-With the same example as above, do the following for each repository beforehand
+First, install [git-filter-repo][git-filter-repo].
+Then, with the same example as above, do the following for each repository beforehand
 (replace `newsubdir` with the name you want):
 
     git clone --mirror git@example.org:repo.git
@@ -91,6 +92,7 @@ Copyright © 2013, 2014 Robin Stocker
 
 Licensed under the Apache License, see LICENSE file for details.
 
+[git-filter-repo]: https://github.com/newren/git-filter-repo
 [maven]: http://maven.apache.org/
 [jgit]: http://eclipse.org/jgit/
 [git-stitch-repo]: http://search.cpan.org/~book/Git-FastExport-0.105/script/git-stitch-repo


### PR DESCRIPTION
``git filter-branch`` is no longer recommended. The git docs suggest to use ``git filter-repo`` instead which has less pitfalls, is faster, and much easier to use.
See https://git-scm.com/docs/git-filter-branch#_warning and https://github.com/newren/git-filter-repo.

This PR replaces the suggested, complex ``filter-branch`` command with the much easier equivalent of ``git filter-repo``. I've used it when merging 20 repositories into one and it worked perfectly fine. The entire history still exists and works after merging repos prepared with this.

P.S.: Thank you for this project - it made my migration to a monorepo very easy. It's hard to find, though - you run into so many articles that just show how to merge master branches, but not everything. Amazing! This should have a much more prominent spot in search results.